### PR TITLE
Expand 'hikes' endpoint to allow filtering criteria

### DIFF
--- a/gorapass/testing/sample_requests.http
+++ b/gorapass/testing/sample_requests.http
@@ -1,0 +1,51 @@
+# Request to fetch all hikes in JSON format
+GET http://localhost:8000/gorapass/hikes HTTP/1.1
+
+###
+
+# Request to fetch all stamps in JSON format
+GET http://localhost:8000/gorapass/stamps HTTP/1.1
+
+###
+
+# Requests to fetch hikes with filtration criteria
+
+# Three hikes have this starting point
+GET http://localhost:8000/gorapass/hikes HTTP/1.1
+content-type: application/json
+
+{
+    "starting_point": "Kraljev dol"
+}
+
+###
+
+# Sending a request with a non-existant attribute return a 400 response
+GET http://localhost:8000/gorapass/hikes HTTP/1.1
+content-type: application/json
+
+{
+    "not_present": "foo"
+}
+
+###
+
+# Sending multiple filters will return hikes who match *all* criteria
+GET http://localhost:8000/gorapass/hikes HTTP/1.1
+content-type: application/json
+
+{
+    "recommended_equipment_summer": "nan",
+    "total_elevation_gain": "1000",
+    "recommended_equipment_winter": "cepin, dereze"
+}
+
+###
+
+# Sending filters that don't match any hikes will return an empty list
+GET http://localhost:8000/gorapass/hikes HTTP/1.1
+content-type: application/json
+
+{
+    "recommended_equipment_summer": "not a value"
+}

--- a/gorapass/testing/sample_requests.http
+++ b/gorapass/testing/sample_requests.http
@@ -15,17 +15,123 @@ GET http://localhost:8000/gorapass/hikes HTTP/1.1
 content-type: application/json
 
 {
-    "starting_point": "Kraljev dol"
+    "filters": [
+        {
+            "attribute_name": "starting_point",
+            "attribute_value": "Kraljev dol",
+            "filter_type": "exact"
+        }    
+    ]
 }
 
 ###
+# We can match parts of words
+GET http://localhost:8000/gorapass/hikes HTTP/1.1
+content-type: application/json
 
+{
+    "filters": [
+        {
+            "attribute_name": "starting_point",
+            "attribute_value": "jev",
+            "filter_type": "partial"
+        }   
+    ]
+}
+
+###
+# We can filter for attributes that are 'less than' some value
+GET http://localhost:8000/gorapass/hikes HTTP/1.1
+content-type: application/json
+
+{
+    "filters": [
+        {
+            "attribute_name": "total_elevation_gain",
+            "attribute_value": 50,
+            "filter_type": "less_than"
+        }
+    ]
+}
+
+###
+# We can filter for attributes that are 'greater than' some value
+GET http://localhost:8000/gorapass/hikes HTTP/1.1
+content-type: application/json
+
+{
+    "filters": [
+        {
+            "attribute_name": "total_elevation_gain",
+            "attribute_value": 3000,
+            "filter_type": "greater_than"
+        }
+    ]
+}
+
+###
+# We can combine 'greater than' and 'less than' to select a range
+GET http://localhost:8000/gorapass/hikes HTTP/1.1
+content-type: application/json
+
+{
+    "filters": [
+        {
+            "attribute_name": "total_elevation_gain",
+            "attribute_value": 3000,
+            "filter_type": "less_than"
+        },
+        {
+            "attribute_name": "total_elevation_gain",
+            "attribute_value": 2000,
+            "filter_type": "greater_than"
+        }
+    ]
+}
+
+###
 # Sending a request with a non-existant attribute return a 400 response
 GET http://localhost:8000/gorapass/hikes HTTP/1.1
 content-type: application/json
 
 {
-    "not_present": "foo"
+    "filters": [
+        {
+            "attribute_name": "not_present",
+            "attribute_value": "Kraljev dol",
+            "filter_type": "exact"
+        }     
+    ]
+}
+
+###
+# Sending a request without the necessary filtration criteria returns a 400 response
+GET http://localhost:8000/gorapass/hikes HTTP/1.1
+content-type: application/json
+
+{
+    "filters": [
+        {
+            "attribute_value": "Kraljev dol",
+            "filter_type": "exact"
+        }     
+    ]
+}
+
+###
+# Sending a request with unknown filtration criteria returns a 400 response
+GET http://localhost:8000/gorapass/hikes HTTP/1.1
+content-type: application/json
+
+{
+    "filters": [
+        {
+            "whoops": "this shouldn't be here",
+            "attribute_name": "starting_location",
+            "attribute_value": "Kraljev dol",
+            "filter_type": "exact"
+        } 
+    ]
 }
 
 ###
@@ -35,9 +141,23 @@ GET http://localhost:8000/gorapass/hikes HTTP/1.1
 content-type: application/json
 
 {
-    "recommended_equipment_summer": "nan",
-    "total_elevation_gain": "1000",
-    "recommended_equipment_winter": "cepin, dereze"
+    "filters": [
+        {
+            "attribute_name": "recommended_equipment_summer",
+            "attribute_value": "nan",
+            "filter_type": "exact"
+        },
+        {
+            "attribute_name": "total_elevation_gain",
+            "attribute_value": 1000,
+            "filter_type": "exact"
+        },
+        {
+            "attribute_name": "recommended_equipment_winter",
+            "attribute_value": "cepin, dereze",
+            "filter_type": "exact"
+        }
+    ]
 }
 
 ###
@@ -47,5 +167,11 @@ GET http://localhost:8000/gorapass/hikes HTTP/1.1
 content-type: application/json
 
 {
-    "recommended_equipment_summer": "not a value"
+    "filters": [
+        {
+            "attribute_name": "starting_point",
+            "attribute_value": "random value",
+            "filter_type": "exact"
+        }  
+    ]
 }

--- a/gorapass/views.py
+++ b/gorapass/views.py
@@ -10,6 +10,17 @@ from django.conf import settings
 from gorapass.models import Stamps
 from gorapass.models import Hikes
 
+ATTRIBUTE_NAME = 'attribute_name'
+ATTRIBUTE_VALUE = 'attribute_value'
+FILTER_TYPE = 'filter_type'
+
+FILTER_KEYS = {
+    ATTRIBUTE_NAME,
+    ATTRIBUTE_VALUE,
+    FILTER_TYPE,
+    }
+
+
 def index(request):
     return HttpResponse('Hello, World. This is Naya and Brandi\'s super cool app.')
 
@@ -27,25 +38,40 @@ def hikes(request):
 
     # Filter out hikes if there is filtration criteria in the request
     if request.body:
-        print('FILTERING HIKES')
-        filtration_criteria = json.loads(request.body)
-        if not valid_hike_filters(filtration_criteria.keys()):
+        filters = json.loads(request.body)['filters']
+        if not valid_hike_filters(filters):
             return HttpResponseBadRequest('Invalid filtration criteria')
 
-        hike_models = filter_hikes(hike_models, filtration_criteria)
+        hike_models = filter_hikes(hike_models, filters)
 
     hike_dicts = [ model_to_dict(hike) for hike in hike_models ]
     return JsonResponse(hike_dicts, safe=False)
 
 def valid_hike_filters(filters):
-    for attribute in filters:
-        if not hasattr(Hikes, attribute):
+    for filter in filters:
+        if set(filter.keys()) != FILTER_KEYS:
             return False
+        if not hasattr(Hikes, filter[ATTRIBUTE_NAME]):
+            return False
+        
     return True
 
-def filter_hikes(hike_models, criteria):
-    for attribute, value in criteria.items():
-        hike_models = [ hike for hike in hike_models if str(getattr(hike, attribute)) == value ]
+def filter_hikes(hike_models, filters):
+    for filter in filters:
+        attribute = filter[ATTRIBUTE_NAME]
+        value = filter[ATTRIBUTE_VALUE]
+        match filter[FILTER_TYPE]:
+            case 'exact':
+                hike_models = [ hike for hike in hike_models if getattr(hike, attribute) == value ]
+            case 'partial':
+                hike_models = [ hike for hike in hike_models if value.lower() in str(getattr(hike, attribute)).lower() ]
+            case 'less_than':
+                hike_models = [ hike for hike in hike_models if getattr(hike, attribute) < value ]
+            case 'greater_than':
+                hike_models = [ hike for hike in hike_models if getattr(hike, attribute) > value ]
+                pass
+            case _:
+                pass
         # Return early if we run out of matching hikes
         if len(hike_models) == 0:
             return hike_models


### PR DESCRIPTION
## The endpoint
The 'hikes' endpoint now accepts a JSON body containing search criteria.

- If there isn't any filtration criteria, we return all hikes
- If there is filtration criteria
    - If the attributes are attributes that exist in our hikes, we will filter and return a list of matching hikes, even if there are none
    - If there are any attributes that *don't* exist as attributes of our hikes, we return a `400 Bad Request` response.

## The documentation
As a sort of running documentation for our API, I've created a file called `sample_requests.http` with demo requests. If you haven't already, you can install the "REST client" extension for VSCode. Once you've done this, there will be a `Send Request` button above each request within the `sample_requests.http` file.