### PR TITLE
Extract out model filtration work

### DIFF
--- a/gorapass/src/filter_models.py
+++ b/gorapass/src/filter_models.py
@@ -1,0 +1,52 @@
+from gorapass.models import Hikes
+
+class ModelFilter:
+    ATTRIBUTE_NAME = 'attribute_name'
+    ATTRIBUTE_VALUE = 'attribute_value'
+    FILTER_TYPE = 'filter_type'
+
+    FILTER_KEYS = {
+        ATTRIBUTE_NAME,
+        ATTRIBUTE_VALUE,
+        FILTER_TYPE,
+    }
+
+    @classmethod
+    def filter_hikes(cls, hike_models, filters):
+        for model_filter in filters:
+            attribute = model_filter[ModelFilter.ATTRIBUTE_NAME]
+            value = model_filter[ModelFilter.ATTRIBUTE_VALUE]
+            match model_filter[ModelFilter.FILTER_TYPE]:
+                case 'exact':
+                    hike_models = [ hike
+                                    for hike in hike_models
+                                    if getattr(hike, attribute) == value ]
+                case 'partial':
+                    hike_models = [ hike
+                                    for hike in hike_models
+                                    if value.lower() in str(getattr(hike, attribute)).lower() ]
+                case 'less_than':
+                    hike_models = [ hike
+                                    for hike in hike_models
+                                    if getattr(hike, attribute) < value ]
+                case 'greater_than':
+                    hike_models = [ hike
+                                    for hike in hike_models
+                                    if getattr(hike, attribute) > value ]
+                case _:
+                    pass
+            # Return early if we run out of matching hikes
+            if len(hike_models) == 0:
+                return hike_models
+
+        return hike_models
+
+    @classmethod
+    def valid_hike_filters(cls, filters):
+        for model_filter in filters:
+            if set(model_filter.keys()) != ModelFilter.FILTER_KEYS:
+                return False
+            if not hasattr(Hikes, model_filter[ModelFilter.ATTRIBUTE_NAME]):
+                return False
+
+        return True

--- a/gorapass/views.py
+++ b/gorapass/views.py
@@ -10,16 +10,7 @@ from django.conf import settings
 from gorapass.models import Stamps
 from gorapass.models import Hikes
 
-ATTRIBUTE_NAME = 'attribute_name'
-ATTRIBUTE_VALUE = 'attribute_value'
-FILTER_TYPE = 'filter_type'
-
-FILTER_KEYS = {
-    ATTRIBUTE_NAME,
-    ATTRIBUTE_VALUE,
-    FILTER_TYPE,
-    }
-
+from .src.filter_models import ModelFilter
 
 def index(request):
     return HttpResponse('Hello, World. This is Naya and Brandi\'s super cool app.')
@@ -39,44 +30,13 @@ def hikes(request):
     # Filter out hikes if there is filtration criteria in the request
     if request.body:
         filters = json.loads(request.body)['filters']
-        if not valid_hike_filters(filters):
+        if not ModelFilter.valid_hike_filters(filters):
             return HttpResponseBadRequest('Invalid filtration criteria')
 
-        hike_models = filter_hikes(hike_models, filters)
+        hike_models = ModelFilter.filter_hikes(hike_models, filters)
 
     hike_dicts = [ model_to_dict(hike) for hike in hike_models ]
     return JsonResponse(hike_dicts, safe=False)
-
-def valid_hike_filters(filters):
-    for filter in filters:
-        if set(filter.keys()) != FILTER_KEYS:
-            return False
-        if not hasattr(Hikes, filter[ATTRIBUTE_NAME]):
-            return False
-        
-    return True
-
-def filter_hikes(hike_models, filters):
-    for filter in filters:
-        attribute = filter[ATTRIBUTE_NAME]
-        value = filter[ATTRIBUTE_VALUE]
-        match filter[FILTER_TYPE]:
-            case 'exact':
-                hike_models = [ hike for hike in hike_models if getattr(hike, attribute) == value ]
-            case 'partial':
-                hike_models = [ hike for hike in hike_models if value.lower() in str(getattr(hike, attribute)).lower() ]
-            case 'less_than':
-                hike_models = [ hike for hike in hike_models if getattr(hike, attribute) < value ]
-            case 'greater_than':
-                hike_models = [ hike for hike in hike_models if getattr(hike, attribute) > value ]
-                pass
-            case _:
-                pass
-        # Return early if we run out of matching hikes
-        if len(hike_models) == 0:
-            return hike_models
-
-    return hike_models
 
 def populate_stamps_datatable(request):
     ## Reset data table to null


### PR DESCRIPTION
In hopes of keeping `views.py` free of clutter, I've extracted out the logic that filters hikes and validates filters. `filter_models.py` lives in a `src` folder that I think we can use for other things as well.

Later on, if we extract the work to parse CSV files (especially if we end up parsing data from other sources), we could put the files in `src` too. Anything that's low-level. Though these modules shouldn't know anything about HTTP or what a 'view' is.

Functionally, this code is the same as before. I made a few small changes, but only superficial ones, like avoiding the variable `filter` so as not to override the built-in `filter` class. 