### PR TITLE
Bs improve filter validation and update terminology

### DIFF
--- a/gorapass/src/filter_models.py
+++ b/gorapass/src/filter_models.py
@@ -5,18 +5,20 @@ class ModelFilter:
     ATTRIBUTE_VALUE = 'attribute_value'
     FILTER_TYPE = 'filter_type'
 
-    FILTER_KEYS = {
+    SELECTOR_KEYS = {
         ATTRIBUTE_NAME,
         ATTRIBUTE_VALUE,
         FILTER_TYPE,
     }
 
+    FILTER_TYPES = { 'exact', 'partial', 'less_than', 'greater_than' }
+
     @classmethod
     def filter_hikes(cls, hike_models, filters):
-        for model_filter in filters:
-            attribute = model_filter[ModelFilter.ATTRIBUTE_NAME]
-            value = model_filter[ModelFilter.ATTRIBUTE_VALUE]
-            match model_filter[ModelFilter.FILTER_TYPE]:
+        for selector in filters:
+            attribute = selector[ModelFilter.ATTRIBUTE_NAME]
+            value = selector[ModelFilter.ATTRIBUTE_VALUE]
+            match selector[ModelFilter.FILTER_TYPE]:
                 case 'exact':
                     hike_models = [ hike
                                     for hike in hike_models
@@ -42,11 +44,34 @@ class ModelFilter:
         return hike_models
 
     @classmethod
-    def valid_hike_filters(cls, filters):
-        for model_filter in filters:
-            if set(model_filter.keys()) != ModelFilter.FILTER_KEYS:
-                return False
-            if not hasattr(Hikes, model_filter[ModelFilter.ATTRIBUTE_NAME]):
-                return False
+    def validate_hike_selectors(cls, selectors):
+        for selector in selectors:
 
-        return True
+            # Check that the keys for the selector object are correct
+            if set(selector.keys()) != ModelFilter.SELECTOR_KEYS:
+                expected = ModelFilter.SELECTOR_KEYS
+                actual = set(selector.keys())
+                message = f'Selector objects must include attributes {expected}, not {actual}'
+
+                return {
+                    'success': False,
+                    'message': message,
+                    }
+
+            # Check that the attribute name exists on hikes
+            attribute_name = selector[ModelFilter.ATTRIBUTE_NAME]
+            if not hasattr(Hikes, attribute_name):
+                return {
+                    'success': False,
+                    'message': f'Attribute: "{attribute_name}" does not exist on Hikes models',
+                    }
+    
+            # Check that the filter type exists
+            filter_type = selector[ModelFilter.FILTER_TYPE]
+            if not filter_type in ModelFilter.FILTER_TYPES:
+                return {
+                    'success': False,
+                    'message': f'Filter type "{filter_type}" does not exist',
+                }
+
+        return { 'success': True }

--- a/gorapass/testing/sample_requests.http
+++ b/gorapass/testing/sample_requests.http
@@ -15,7 +15,7 @@ GET http://localhost:8000/gorapass/hikes HTTP/1.1
 content-type: application/json
 
 {
-    "filters": [
+    "selectors": [
         {
             "attribute_name": "starting_point",
             "attribute_value": "Kraljev dol",
@@ -30,7 +30,7 @@ GET http://localhost:8000/gorapass/hikes HTTP/1.1
 content-type: application/json
 
 {
-    "filters": [
+    "selectors": [
         {
             "attribute_name": "starting_point",
             "attribute_value": "jev",
@@ -45,7 +45,7 @@ GET http://localhost:8000/gorapass/hikes HTTP/1.1
 content-type: application/json
 
 {
-    "filters": [
+    "selectors": [
         {
             "attribute_name": "total_elevation_gain",
             "attribute_value": 50,
@@ -60,7 +60,7 @@ GET http://localhost:8000/gorapass/hikes HTTP/1.1
 content-type: application/json
 
 {
-    "filters": [
+    "selectors": [
         {
             "attribute_name": "total_elevation_gain",
             "attribute_value": 3000,
@@ -75,7 +75,7 @@ GET http://localhost:8000/gorapass/hikes HTTP/1.1
 content-type: application/json
 
 {
-    "filters": [
+    "selectors": [
         {
             "attribute_name": "total_elevation_gain",
             "attribute_value": 3000,
@@ -95,7 +95,7 @@ GET http://localhost:8000/gorapass/hikes HTTP/1.1
 content-type: application/json
 
 {
-    "filters": [
+    "selectors": [
         {
             "attribute_name": "not_present",
             "attribute_value": "Kraljev dol",
@@ -110,7 +110,7 @@ GET http://localhost:8000/gorapass/hikes HTTP/1.1
 content-type: application/json
 
 {
-    "filters": [
+    "selectors": [
         {
             "attribute_value": "Kraljev dol",
             "filter_type": "exact"
@@ -124,12 +124,27 @@ GET http://localhost:8000/gorapass/hikes HTTP/1.1
 content-type: application/json
 
 {
-    "filters": [
+    "selectors": [
         {
             "whoops": "this shouldn't be here",
             "attribute_name": "starting_location",
             "attribute_value": "Kraljev dol",
             "filter_type": "exact"
+        } 
+    ]
+}
+
+###
+# Sending a request with an invalid filter type returns a 400 response
+GET http://localhost:8000/gorapass/hikes HTTP/1.1
+content-type: application/json
+
+{
+    "selectors": [
+        {
+            "attribute_name": "starting_point",
+            "attribute_value": "Kraljev dol",
+            "filter_type": "exact_match"
         } 
     ]
 }
@@ -141,7 +156,7 @@ GET http://localhost:8000/gorapass/hikes HTTP/1.1
 content-type: application/json
 
 {
-    "filters": [
+    "selectors": [
         {
             "attribute_name": "recommended_equipment_summer",
             "attribute_value": "nan",
@@ -167,7 +182,7 @@ GET http://localhost:8000/gorapass/hikes HTTP/1.1
 content-type: application/json
 
 {
-    "filters": [
+    "selectors": [
         {
             "attribute_name": "starting_point",
             "attribute_value": "random value",

--- a/gorapass/views.py
+++ b/gorapass/views.py
@@ -29,11 +29,12 @@ def hikes(request):
 
     # Filter out hikes if there is filtration criteria in the request
     if request.body:
-        filters = json.loads(request.body)['filters']
-        if not ModelFilter.valid_hike_filters(filters):
-            return HttpResponseBadRequest('Invalid filtration criteria')
+        selectors = json.loads(request.body)['selectors']
+        valid_selectors_status = ModelFilter.validate_hike_selectors(selectors)
+        if not valid_selectors_status['success']:
+            return HttpResponseBadRequest(valid_selectors_status['message'])
 
-        hike_models = ModelFilter.filter_hikes(hike_models, filters)
+        hike_models = ModelFilter.filter_hikes(hike_models, selectors)
 
     hike_dicts = [ model_to_dict(hike) for hike in hike_models ]
     return JsonResponse(hike_dicts, safe=False)


### PR DESCRIPTION
A few things happen here:

1. I changed terminology such that each object is a 'selector' rather than a 'filter'. Since the selectors themselves contain filters, like 'greater_than', 'less_than', etc... The more I wrote the less clear this became. Selectors are the objects you can pass with requests to select hikes that meet certain criteria. Filters are the different ways in which you can select hikes.

2. Instead of returning a generic error message when the selectors were invalid, we now return something more helpful to show what was wrong with the request. Ex: 'Attribute "hike_start_point" does not exist on Hikes models"

3. Add validation so that only our current filtration criteria are accepted. Right now we have:

- less_than
- greater_than
- exact
- partial

Note that this PR is stacked on top of [`bs-extract-helpers`](https://github.com/brandiseeley/gorapass/tree/bs-extract-helpers).