### PR TITLE
Make filtration work with POST requests from front-end server

### DIFF
--- a/gorapass/testing/sample_requests.http
+++ b/gorapass/testing/sample_requests.http
@@ -287,3 +287,18 @@ content-type: application/json
         }
     ]
 }
+
+###
+# Sending stamp filter works
+GET http://localhost:8000/gorapass/hikes HTTP/1.1
+content-type: application/json
+
+{
+    "selectors": [
+        {
+            "attribute_name": "stamp_id",
+            "attribute_value": 1299,
+            "filter_type": "exact"
+        }
+    ]
+}

--- a/hikepass/settings.py
+++ b/hikepass/settings.py
@@ -39,6 +39,8 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'corsheaders',
+    'rest_framework',
+
 ]
 
 MIDDLEWARE = [
@@ -51,6 +53,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
+
 
 ROOT_URLCONF = 'hikepass.urls'
 
@@ -126,5 +129,11 @@ STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 CORS_ALLOWED_ORIGINS = [
+    "http://localhost:5173" ## React local server
+]
+
+CORS_ALLOW_CREDENTIALS = True
+
+CSRF_TRUSTED_ORIGINS = [
     "http://localhost:5173" ## React local server
 ]


### PR DESCRIPTION
I had to update some CORS/CSRF related settings in order to make POST requests work for selectors from the front-end server. 

We still need to update the tests to POST requests.