### PR TITLE
Allow for POST requests with no request body

### DIFF
--- a/gorapass/views.py
+++ b/gorapass/views.py
@@ -26,7 +26,7 @@ def stamp(request, stamp_id):
 def stamps(request):
     stamp_models = Stamps.objects.all()
 
-    if request.method == 'GET':
+    if request.method == 'GET' or len(request.body) == 0:
         stamp_dict = [ model_to_dict(stamp) for stamp in stamp_models ]
     elif request.method == 'POST':
         # Filter out stamps if there is filtration criteria on the request
@@ -53,7 +53,7 @@ def hike(request, hike_id):
 def hikes(request):
     hike_models = Hikes.objects.all()
 
-    if request.method == 'GET':
+    if request.method == 'GET' or len(request.body) == 0:
         hike_dicts = [ model_to_dict(stamp) for stamp in hike_models ]
     elif request.method == 'POST':
         # Filter out hikes if there is filtration criteria in the request


### PR DESCRIPTION
After updating to allow for `GET` and `POST` requests, a `POST` request with no body with throw an error. Now, the app will behave like a `GET` request when receiving a `POST` request with no body.