### PR TITLE
Extract POST request validation across views

### DIFF
--- a/gorapass/src/filter_models.py
+++ b/gorapass/src/filter_models.py
@@ -44,6 +44,9 @@ class ModelFilter:
 
     @classmethod
     def validate_selectors(cls, data_models, selectors):
+        if not selectors:
+            return { 'success': False,
+                     'message': 'No selectors provided' }
         for selector in selectors:
 
             # Check that the keys for the selector object are correct

--- a/gorapass/src/utils.py
+++ b/gorapass/src/utils.py
@@ -1,0 +1,19 @@
+import json
+from django.http import HttpResponseBadRequest
+
+def get_json_data_or_401(request):
+    """
+    Used to parse and return JSON from a request that's expected
+    to be a POST request containing JSON as the body
+    """
+    if request.method != 'POST':
+        return HttpResponseBadRequest('Expected a POST request')
+    if not request.body:
+        return HttpResponseBadRequest('POST request must contain a body')
+
+    try:
+        data = json.loads(request.body)
+    except ValueError:
+        return HttpResponseBadRequest('Body must contain valid JSON')
+
+    return data

--- a/gorapass/tests.py
+++ b/gorapass/tests.py
@@ -558,7 +558,7 @@ class UserTestCase(TestCase):
 
     def test_user_login_no_body(self):
         response = UserTestCase.client.post('/gorapass/users/login')
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 401)
 
     def test_user_page_not_logged_in(self):
         response = UserTestCase.client.get('/gorapass/users/1')


### PR DESCRIPTION
As we got more endpoints expecting POST requests with JSON data, the validation became repetitive and inconsistent. This PR creates a `utils.py` file for helper functions that can process requests in generic ways.

Right now, I've just added one function, `get_json_data_or_401`. Much like Django's shortcut, `get_object_or_404`, the idea is to expect some data and return it, but if that doesn't go as planned, return a 401 BadRequest for whatever reason it may be.

This can be used anywhere that we expect a POST request that contains some JSON data as the body.