### PR TITLE
is_authenticated route and test

### DIFF
--- a/gorapass/tests.py
+++ b/gorapass/tests.py
@@ -564,6 +564,27 @@ class UserTestCase(TestCase):
         response = UserTestCase.client.get('/gorapass/users/1')
         self.assertEqual(response.status_code, 401)
 
+    def test_is_authenticated(self):
+        response = UserTestCase.client.get('/gorapass/users/is_authenticated')
+        self.assertEqual(response.status_code, 401)
+
+        credentials = {
+            'username': 'jane_doe',
+            'password': 'gorapass',
+        }
+
+        data = json.dumps(credentials)
+        response = UserTestCase.client.post('/gorapass/users/login', data, content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+
+        response = UserTestCase.client.get('/gorapass/users/is_authenticated')
+        self.assertEqual(response.status_code, 200)
+
+        UserTestCase.client.get('/gorapass/users/logout')
+
+        response = UserTestCase.client.get('/gorapass/users/is_authenticated')
+        self.assertEqual(response.status_code, 401)
+
     def test_user_page_logged_in(self):
         UserTestCase.client.login(username='jane_doe', password='gorapass')
         response = UserTestCase.client.get('/gorapass/users/1')

--- a/gorapass/urls.py
+++ b/gorapass/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
     path('users/<int:user_id>/completed_hikes/delete', views.delete_completed_hike, name='delete_completed_hike'),
     path('users/<int:user_id>/completed_stamps', views.user_completed_stamps, name='user_completed_stamps'),
     path('users/<int:user_id>/completed_stamps/add', views.add_completed_stamp, name='add_completed_stamp'),
+    path('users/is_authenticated', views.is_authenticated, name='is_authenticated'),
     path('users/login', views.login_user, name='login'),
     path('users/logout', views.logout_user, name='logout'),
     path('users/login_test_user', views.login_test_user, name="login_test_user"),

--- a/gorapass/views.py
+++ b/gorapass/views.py
@@ -102,6 +102,12 @@ def add_completed_stamp(request, user_id):
 def delete_completed_stamp(request, user_id):
     pass
 
+def is_authenticated(request):
+    if request.user.is_authenticated:
+        return HttpResponse(f'You\'re already logged in as {request.user}')
+    else:
+        return HttpResponse('Unauthorized', status=401)
+
 def login_user(request):
     """Logs a user in when given a POST request with JSON including a valid username and password"""
     body = get_json_data_or_401(request)


### PR DESCRIPTION
This is the endpoint to check if a user is logged in or not. 

200 if someone is logged in already, 401 if not. I was thinking that it doesn't  really make sense to send a 401 if they aren't logged in...because the request is successful, but I'm not sure what else to do. Sending a 200 and checking the body seems like a pain relative to just sending an unsuccessful response. I guess if you take the perspective that you *expect* them to be logged in, a 401 is okay. Not sure. What do you think?